### PR TITLE
Fixed issue with "a" command wrapping lines.

### DIFF
--- a/src/vibreoffice.vbs
+++ b/src/vibreoffice.vbs
@@ -367,7 +367,23 @@ Function ProcessModeKey(oEvent)
     Select Case oEvent.KeyChar
         ' Insert modes
         Case "i", "a", "I", "A", "o", "O":
-            If oEvent.KeyChar = "a" Then getCursor().goRight(1, False)
+            If oEvent.KeyChar = "a" Then
+                dim oldPos, newPos, cursor
+                cursor = getCursor()
+
+                ' oldPos and newPos are used to make sure we haven't moved down
+                oldPos = cursor.getPosition()
+                cursor.goRight(1, False)
+                newPos = cursor.getPosition()
+
+                ' If the result is at the start of the line, then it must have
+                ' jumped down a line; goLeft to return to the previous line.
+                '   Except for: Empty lines (check for oldPos = newPos)
+                If cursor.isAtStartOfLine() And oldPos.Y() <> newPos.Y() Then
+                    cursor.goLeft(1, true)
+                End If
+
+            End If
             If oEvent.KeyChar = "I" Then ProcessMovementKey("^")
             If oEvent.KeyChar = "A" Then ProcessMovementKey("$")
 


### PR DESCRIPTION
If the cursor was on the end of a line and 'a' was pressed, the cursor
would wrap to the next line instead of remaining on the current one.
This has already been fixed for "A", and so this was corrected in the
same way.

Also @seanyeh before you consider merging this in, I do have one small question to make sure I got this right. What is the function of the boolean second argument in goLeft() and goRight()? In the Libreoffice API Docs they say that determines if it expands the current selection, but frankly I have no idea what that means. Which should I use, true or false, and what is the difference?
